### PR TITLE
feat: randomized initial hints configuration (#11)

### DIFF
--- a/src/data/balance.json
+++ b/src/data/balance.json
@@ -12,8 +12,9 @@
       "effectiveness": 25
     },
     "initial_hints": [
-      "stat",
-      "stat"
+      ["stat", "stat"],
+      ["stat", "effectiveness"],
+      ["stat", "fully_evolved"]
     ]
   },
   "medium": {
@@ -29,7 +30,8 @@
       "effectiveness": 35
     },
     "initial_hints": [
-      "stat"
+      ["stat"],
+      ["effectiveness"]
     ]
   },
   "hard": {
@@ -45,7 +47,7 @@
       "effectiveness": 45
     },
     "initial_hints": [
-      "stat"
+      ["stat"]
     ]
   }
 }

--- a/src/domain/balance.py
+++ b/src/domain/balance.py
@@ -20,7 +20,7 @@ class Difficulty(BaseModel):
     max_battery: int
     battery_recovery: int
     hint_costs: HintCosts
-    initial_hints: list[str] = []
+    initial_hints: list[list[str]] = []
 
 
 class DifficultyConfig(BaseModel):

--- a/src/services/start_game.py
+++ b/src/services/start_game.py
@@ -38,9 +38,13 @@ class StartGame:
             battery_recovery=difficulty_settings.battery_recovery,
             user_id=user_id,
         )
-        for hint_type_name in difficulty_settings.initial_hints:
-            hint = self.hint_registry.create(
-                hint_type_name, pokemon, game.hints, self.random_generator
-            )
-            game.hints.append(hint)
+        hint_sets = difficulty_settings.initial_hints
+        if hint_sets:
+            index = self.random_generator.randint(0, len(hint_sets) - 1)
+            selected_hints = hint_sets[index]
+            for hint_type_name in selected_hints:
+                hint = self.hint_registry.create(
+                    hint_type_name, pokemon, game.hints, self.random_generator
+                )
+                game.hints.append(hint)
         return await self.game_repository.save(game)

--- a/tests/test_start_game.py
+++ b/tests/test_start_game.py
@@ -2,7 +2,7 @@ import pytest
 
 from domain.balance import Difficulty, DifficultyConfig, HintCosts
 from domain.difficulty import DifficultyLevel
-from domain.hint import StatHint
+from domain.hint import EffectivenessHint, StatHint
 from domain.hint_factory import HintCreatorRegistry, create_hint_registry
 from domain.pokemon import Pokemon
 from domain.ports.repositories import GameRepository
@@ -43,7 +43,7 @@ def difficulty_config() -> DifficultyConfig:
         max_battery=100,
         battery_recovery=10,
         hint_costs=HintCosts(stat=40, primary_type=30, secondary_type=30),
-        initial_hints=["stat"],
+        initial_hints=[["stat"]],
     )
     return _create_difficulty_config(difficulty)
 
@@ -133,7 +133,7 @@ async def test_creates_game_with_easy_difficulty(
         max_battery=150,
         battery_recovery=35,
         hint_costs=HintCosts(stat=30),
-        initial_hints=["stat", "stat"],
+        initial_hints=[["stat", "stat"]],
     )
     difficulty_config = DifficultyConfig(difficulties={DifficultyLevel.EASY: easy_difficulty})
     pokemon_selector = FakePokemonSelector(pikachu)
@@ -178,3 +178,85 @@ async def test_creates_game_with_hard_difficulty(
     assert game.max_battery == 60
     assert game.battery_recovery == 15
     assert len(game.hints) == 0
+
+
+@pytest.mark.asyncio
+async def test_randomly_selects_hint_set(
+    game_repository: GameRepository, pikachu: Pokemon,
+    hint_registry: HintCreatorRegistry,
+) -> None:
+    difficulty = Difficulty(
+        max_attempts=4,
+        initial_battery=100,
+        max_battery=100,
+        battery_recovery=10,
+        hint_costs=HintCosts(stat=40, effectiveness=35),
+        initial_hints=[["stat", "stat"], ["effectiveness"]],
+    )
+    difficulty_config = _create_difficulty_config(difficulty)
+    pokemon_selector = FakePokemonSelector(pikachu)
+
+    # Select index 1 -> ["effectiveness"]
+    random_generator = FakeRandomGenerator(1)
+
+    start_game = StartGame(
+        pokemon_selector, random_generator, game_repository, difficulty_config, hint_registry
+    )
+    game = await start_game.execute()
+
+    assert len(game.hints) == 1
+    assert isinstance(game.hints[0], EffectivenessHint)
+
+
+@pytest.mark.asyncio
+async def test_selects_first_hint_set_when_index_zero(
+    game_repository: GameRepository, pikachu: Pokemon,
+    hint_registry: HintCreatorRegistry,
+) -> None:
+    difficulty = Difficulty(
+        max_attempts=4,
+        initial_battery=100,
+        max_battery=100,
+        battery_recovery=10,
+        hint_costs=HintCosts(stat=40, effectiveness=35),
+        initial_hints=[["stat", "stat"], ["effectiveness"]],
+    )
+    difficulty_config = _create_difficulty_config(difficulty)
+    pokemon_selector = FakePokemonSelector(pikachu)
+
+    # Select index 0 -> ["stat", "stat"]
+    random_generator = FakeRandomGenerator(0)
+
+    start_game = StartGame(
+        pokemon_selector, random_generator, game_repository, difficulty_config, hint_registry
+    )
+    game = await start_game.execute()
+
+    assert len(game.hints) == 2
+    assert all(isinstance(h, StatHint) for h in game.hints)
+
+
+@pytest.mark.asyncio
+async def test_single_hint_set_always_selected(
+    game_repository: GameRepository, pikachu: Pokemon,
+    hint_registry: HintCreatorRegistry,
+) -> None:
+    difficulty = Difficulty(
+        max_attempts=4,
+        initial_battery=100,
+        max_battery=100,
+        battery_recovery=10,
+        hint_costs=HintCosts(stat=40),
+        initial_hints=[["stat"]],
+    )
+    difficulty_config = _create_difficulty_config(difficulty)
+    pokemon_selector = FakePokemonSelector(pikachu)
+    random_generator = FakeRandomGenerator(0)
+
+    start_game = StartGame(
+        pokemon_selector, random_generator, game_repository, difficulty_config, hint_registry
+    )
+    game = await start_game.execute()
+
+    assert len(game.hints) == 1
+    assert isinstance(game.hints[0], StatHint)


### PR DESCRIPTION
## Summary

- Refactors difficulty configuration to support multiple sets of initial hints (list of lists) instead of a single fixed list
- On game start, the system randomly selects one hint set from the available options for the chosen difficulty level
- Only affects game initialization (`POST /games`); no changes to hint request endpoints during active gameplay

Closes #11

## Architecture Decisions

- **Schema change in domain layer**: `Difficulty.initial_hints` type changed from `list[str]` to `list[list[str]]` in the Pydantic model, providing automatic validation of the new nested structure at config load time
- **Random selection in service layer**: The `StartGame.execute()` method uses the existing `RandomGenerator` port (already injected) to pick the hint set index, keeping the domain model free of randomness concerns
- **No new ports or interfaces**: The existing `RandomGenerator.randint()` protocol is sufficient for the selection logic
- **Backward-compatible empty list handling**: An empty `initial_hints: []` still results in no initial hints, preserving the hard difficulty behavior

## Security Review Summary

No HIGH or MEDIUM priority findings. The implementation follows SOLID principles:

- **Dependency Inversion**: Random selection uses the injected `RandomGenerator` port, not direct `random` module calls
- **Open/Closed**: New hint sets can be added to `balance.json` without code changes
- **Input Validation**: Pydantic validates the `list[list[str]]` structure at config load time; `HintCreatorRegistry` validates hint type names at runtime

### Known Issues / Future Improvements (LOW priority)

- The shared `RandomGenerator` instance is used for both hint set selection and individual hint randomization (e.g., stat selection) within the same `execute()` call. This is correct behavior for production but worth noting for test design awareness.
- Empty inner lists (e.g., `[[]]`) are technically valid and result in no hints for that selection. Could add explicit validation if desired.

## Testing

Added 3 new tests to `tests/test_start_game.py`:
- `test_randomly_selects_hint_set` -- verifies that index 1 selects the second hint set (effectiveness hint)
- `test_selects_first_hint_set_when_index_zero` -- verifies that index 0 selects the first hint set (two stat hints)
- `test_single_hint_set_always_selected` -- verifies deterministic behavior with a single-element list

Updated 3 existing tests to use the new `list[list[str]]` format. All 171 tests pass.

## Files Changed

| File | Change |
|------|--------|
| `src/domain/balance.py` | `initial_hints: list[str]` -> `list[list[str]]` |
| `src/services/start_game.py` | Added random selection of hint set before iterating |
| `src/data/balance.json` | Updated all difficulty levels to use nested array format |
| `tests/test_start_game.py` | Updated existing tests + added 3 new randomization tests |

🤖 Generated with [Claude Code](https://claude.com/claude-code)